### PR TITLE
modified application.rb for image showing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,4 +23,8 @@ module Mcamp
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
   end
+
+  ###### added by mike
+  config.serve_static_assets = true
+  ########
 end


### PR DESCRIPTION
snipped from https://devcenter.heroku.com/articles/rails-4-asset-pipeline

Serve assets

By default Rails 4 will not serve your assets. To enable this functionality you need to go into config/application.rb and add this line:

config.serve_static_assets = true
